### PR TITLE
second-order BK failure patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+DifferenceEquations = "e0ca9c66-1f9e-11ec-127a-1304ce62169c"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.4.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-DifferenceEquations = "e0ca9c66-1f9e-11ec-127a-1304ce62169c"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -29,7 +28,6 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ChainRulesCore = "1"
-DifferenceEquations="0.2"
 Distributions = "0.25"
 DistributionsAD = "0.6"
 DocStringExtensions = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ChainRulesCore = "1"
+DifferenceEquations="0.2"
 Distributions = "0.25"
 DistributionsAD = "0.6"
 DocStringExtensions = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "DifferentiableStateSpaceModels"
 uuid = "beacd9db-9e5e-4956-9b09-459a4b2028df"
 authors = ["Jesse Perla <jesseperla@gmail.com> and contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-DifferenceEquations = "e0ca9c66-1f9e-11ec-127a-1304ce62169c"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DistributionsAD = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -29,7 +28,6 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ChainRulesCore = "1"
-DifferenceEquations="0.2"
 Distributions = "0.25"
 DistributionsAD = "0.6"
 DocStringExtensions = "0.8"

--- a/src/DifferentiableStateSpaceModels.jl
+++ b/src/DifferentiableStateSpaceModels.jl
@@ -1,6 +1,6 @@
 module DifferentiableStateSpaceModels
 
-using DifferenceEquations
+# using DifferenceEquations
 using Logging
 using MatrixEquations
 using TensorCast

--- a/src/generate_perturbation.jl
+++ b/src/generate_perturbation.jl
@@ -44,7 +44,7 @@ function generate_perturbation(m::PerturbationModel, p_d, p_f, order::Val{2};
     # Calculate the first-order perturbation
     sol_first = generate_perturbation(m, p_d, p_f, Val(1); cache, settings)
 
-    (sol_first.retcode == :Success) || return SecondOrderPerturbationSolution(ret, m, cache)
+    (sol_first.retcode == :Success) || return SecondOrderPerturbationSolution(sol_first.retcode, m, cache)
 
     # solver type provided to all callbacks
     ret = evaluate_second_order_functions!(m, cache, settings, p)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,3 +1,5 @@
+import Base.deepcopy_internal
+deepcopy_internal(x::Module,stackdict::IdDict) = x
 
 # Model Types.  The template args are required for inference for cache/perturbation solutions
 struct PerturbationModel{MaxOrder,N_y,N_x,N_ϵ,N_z,N_p,HasΩ,T1,T2}

--- a/test/second_order_perturbation.jl
+++ b/test/second_order_perturbation.jl
@@ -537,3 +537,13 @@ end
     _, pb = Zygote.pullback(generate_perturbation, m, p_d, p_f, Val(2))
     @inferred pb(sol)
 end
+
+@testset "BK Condition Failure" begin
+      m = @include_example_module(Examples.rbc)
+      p_f = nothing
+      p_d = (α = 0.5, β = 0.95, ρ = 1.01, δ = 0.02, σ = 0.01) # rho > 1
+      settings = PerturbationSolverSettings(; print_level = 2)
+      c = SolverCache(m, Val(2), p_d)
+      sol = generate_perturbation(m, p_d, p_f, Val(2); settings)
+      @test sol.retcode == :BlanchardKahnFailure
+  end


### PR DESCRIPTION
This PR fixes the issue that when BK fails, the second-order perturbation solution triggers an error instead of returning an error message. I added a corresponding unit test as well.