### PR TITLE
use the discrete version of sylvester

### DIFF
--- a/src/generate_perturbation_derivatives.jl
+++ b/src/generate_perturbation_derivatives.jl
@@ -176,10 +176,10 @@ function solve_second_order_p!(m, c, settings)
         # General Prep
         buff.A .= [c.H_y c.H_xp + c.H_yp * c.g_x]
         buff.B .= c.I_x_2
-        buff.C .= [c.H_yp zeros(n, n_x)]
+        buff.C .= buff.A \ [c.H_yp zeros(n, n_x)]
         kron!(buff.D, c.h_x, c.h_x)
-        AS, CS, Q1, Z1 = schur!(buff.A, buff.C)
-        BS, DS, Q2, Z2 = schur!(buff.B, buff.D)
+        RC, QC = schur!(buff.C)
+        RD, QD = schur!(buff.D)
         buff.E .= zeros(n, n_x * n_x)
         buff.R .= vcat(c.g_x * c.h_x, c.g_x, c.h_x, c.I_x)
         buff.A_σ .= [c.H_yp + c.H_y c.H_xp + c.H_yp * c.g_x]
@@ -250,9 +250,9 @@ function solve_second_order_p!(m, c, settings)
 
             # Solve the Sylvester equations (56)
             # X = gsylv(A, B, C, D, E)
-            Y = adjoint(Q1) * (buff.E * Z2)
-            gsylvs!(AS, BS, CS, DS, Y)
-            X = Z1 * (Y * adjoint(Q2))
+            Y = adjoint(QC) * (buff.A \ buff.E) * QD
+            sylvds!(RC, RD, Y)
+            X = QC * (Y * adjoint(QD))
             copyto!(c.g_xx_p[i], X[1:n_y, :]) # Reshaping into n_y * n_x * n_x
             copyto!(c.h_xx_p[i], X[(n_y + 1):end, :]) # # Reshaping into n_x * n_x * n_x
 


### PR DESCRIPTION
Attached is the results from `judge.md`

A ratio greater than `1.0` denotes a possible regression (marked with :x:), while a ratio less
than `1.0` denotes a possible improvement (marked with :white_check_mark:). Only significant results - results
that indicate possible regressions or improvements - are shown below (thus, an empty table means that all
benchmark results remained invariant between builds).

| ID                                                        | time ratio                   | memory ratio |
|-----------------------------------------------------------|------------------------------|--------------|
| `["fvgq", "fvgq", "first_order"]`                         | 0.91 (5%) :white_check_mark: |   1.00 (1%)  |
| `["fvgq", "fvgq", "second_order_no_cache"]`               |                1.09 (5%) :x: |   1.00 (1%)  |
| `["fvgq", "fvgq", "second_order_p"]`                      | 0.57 (5%) :white_check_mark: |   1.00 (1%)  |
| `["rbc", "rbc_observables", "second_order_p"]`            | 0.91 (5%) :white_check_mark: |   0.99 (1%)  |
| `["sgu", "sgu", "first_order"]`                           | 0.91 (5%) :white_check_mark: |   1.00 (1%)  |
| `["sgu", "sgu", "second_order_p"]`                        | 0.70 (5%) :white_check_mark: |   1.01 (1%)  |